### PR TITLE
[FIXED JENKINS-11379] add original localDir to new ModuleLocation

### DIFF
--- a/src/main/java/jenkins/plugins/svnmerge/IntegratableProjectAction.java
+++ b/src/main/java/jenkins/plugins/svnmerge/IntegratableProjectAction.java
@@ -93,7 +93,8 @@ public class IntegratableProjectAction extends AbstractModelObject implements Ac
 
         // TODO: check for multiple locations
         SubversionSCM svn = (SubversionSCM) scm;
-        String url = svn.getLocations()[0].getURL();
+        ModuleLocation firstLocation = svn.getLocations()[0];
+		String url = firstLocation.getURL();
         Matcher m = KEYWORD.matcher(url);
         if(!m.find()) {
             sendError("Unable to infer the new branch name from "+url);
@@ -123,7 +124,7 @@ public class IntegratableProjectAction extends AbstractModelObject implements Ac
 
                 // create a branch
                 svnm.getCopyClient().doCopy(
-                    svn.getLocations()[0].getSVNURL(), SVNRevision.HEAD,
+                    firstLocation.getSVNURL(), SVNRevision.HEAD,
                     dst, false, true,
                     "Created a feature branch from Jenkins");
             } catch (SVNException e) {
@@ -142,7 +143,7 @@ public class IntegratableProjectAction extends AbstractModelObject implements Ac
             SubversionSCM svnScm = (SubversionSCM)copy.getScm();
             copy.setScm(
                     new SubversionSCM(
-                            Arrays.asList(new ModuleLocation(url,null)),
+                            Arrays.asList(new ModuleLocation(url,firstLocation.getLocalDir())),
                                 svnScm.getWorkspaceUpdater(), svnScm.getBrowser(),
                                 svnScm.getExcludedRegions(),
                                 svnScm.getExcludedUsers(),


### PR DESCRIPTION
Hi,

Fixes [JENKINS-11379](https://issues.jenkins-ci.org/browse/JENKINS-11379) by adding the original localDir to the new ModuleLocation
