### PR TITLE
Update RebaseAction.java

### DIFF
--- a/src/main/java/jenkins/plugins/svnmerge/RebaseAction.java
+++ b/src/main/java/jenkins/plugins/svnmerge/RebaseAction.java
@@ -148,5 +148,5 @@ public class RebaseAction extends AbstractSvnmergeTaskAction<RebaseSetting> {
         }
     }
 
-    public static final String COMMIT_MESSAGE_PREFIX = "[REBASE] ";
+    public static final String COMMIT_MESSAGE_PREFIX = "REBASE ";
 }


### PR DESCRIPTION
Invalid syntax in commit log: [REBASE] Rebasing from [...]
The '[' and ']' characters are used to enclose notifications for
issue tracking systems (e.g. to close ticket 23 use '[t:23, v:close]')).
