### PR TITLE
[FIX JENKINS-25769] Use root build on a promotion build

### DIFF
--- a/src/main/java/jenkins/plugins/svnmerge/IntegrationPublisher.java
+++ b/src/main/java/jenkins/plugins/svnmerge/IntegrationPublisher.java
@@ -1,5 +1,7 @@
 package jenkins.plugins.svnmerge;
 
+import static jenkins.plugins.svnmerge.Utility.rootBuildOf;
+
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -39,7 +41,8 @@ public class IntegrationPublisher extends Publisher {
         if(build.getResult().isWorseThan(Result.SUCCESS))
             return true;
 
-        IntegrateAction ia= getIntegrateAction(build);
+        //JENKINS-14725 If this is a promotion build, then we need to get the rootBuild
+        IntegrateAction ia = rootBuildOf(build).getAction(IntegrateAction.class);
         if(ia==null) {
             listener.getLogger().println("Upstream Subversion URL is not specified. Configuration problem?");
             return false;
@@ -64,17 +67,5 @@ public class IntegrationPublisher extends Publisher {
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
         }
-    }
-
-    public IntegrateAction getIntegrateAction(AbstractBuild build) {
-        IntegrateAction ia = build.getAction(IntegrateAction.class);
-        //JENKINS-14725 If this is a promotion build, then we need to get the rootBuild
-        if (Jenkins.getInstance().getPlugin("promoted-builds")!=null) {
-            if(build instanceof hudson.plugins.promoted_builds.Promotion){
-                AbstractBuild<?,?> rootBuild = build.getRootBuild();
-                ia = rootBuild.getAction(IntegrateAction.class);
-            }
-        }
-        return ia;
     }
 }

--- a/src/main/java/jenkins/plugins/svnmerge/RebaseBuilder.java
+++ b/src/main/java/jenkins/plugins/svnmerge/RebaseBuilder.java
@@ -1,5 +1,7 @@
 package jenkins.plugins.svnmerge;
 
+import static jenkins.plugins.svnmerge.Utility.rootBuildOf;
+
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -35,7 +37,8 @@ public class RebaseBuilder extends Builder {
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        AbstractProject<?,?> project = build.getProject();
+        //JENKINS-25769 If this is a promotion build, then we need to get the rootBuild
+        AbstractProject<?,?> project = rootBuildOf(build).getProject();
         FeatureBranchProperty property = project.getProperty(FeatureBranchProperty.class);
 
         if (property == null) {

--- a/src/main/java/jenkins/plugins/svnmerge/Utility.java
+++ b/src/main/java/jenkins/plugins/svnmerge/Utility.java
@@ -1,6 +1,7 @@
 package jenkins.plugins.svnmerge;
 
 import hudson.EnvVars; 
+import hudson.model.AbstractBuild;
 import hudson.model.Computer;
 import hudson.model.Job;
 import hudson.scm.SubversionSCM.ModuleLocation;
@@ -13,13 +14,27 @@ import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
 
-public class Utility {
+class Utility {
+
+    /**
+     * Get either the provided build of the root build of the provided
+     * build if it is a promotion one.
+     */
+    static AbstractBuild<?,?> rootBuildOf(AbstractBuild build) {
+        if (Jenkins.getInstance().getPlugin("promoted-builds") != null) {
+            if (build instanceof hudson.plugins.promoted_builds.Promotion) {
+                return build.getRootBuild();
+            }
+        }
+        
+        return build;
+    }
 
 	
     /**
      * Expands the system variables, the node environment variables and the project parameters
      */
-	public static ModuleLocation getExpandedLocation(ModuleLocation ml, Job<?,?> project) {
+	static ModuleLocation getExpandedLocation(ModuleLocation ml, Job<?,?> project) {
 		 ModuleLocation location= ml.getExpandedLocation(project);
 		// expand system variables
 		Computer c = Computer.currentComputer();


### PR DESCRIPTION
Move the utility method to retrieve root build of promotion builds in `Utility` and use it in `RebaseBuilder`.
