### PR TITLE
Mark as unstable on failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
       <version>2.15</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>matrix-project</artifactId>
+        <version>1.3</version>
+        <optional>true</optional>
+    </dependency>
   </dependencies>
 
 </project>  

--- a/src/main/java/jenkins/plugins/svnmerge/RebaseBuilder.java
+++ b/src/main/java/jenkins/plugins/svnmerge/RebaseBuilder.java
@@ -8,6 +8,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.PermalinkProjectAction.Permalink;
+import hudson.model.Result;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.ListBoxModel;
@@ -28,11 +29,13 @@ public class RebaseBuilder extends Builder {
      * Indicates whether to stop the build if the merge fails. 
      */
     public final boolean stopBuildIfMergeFails;
+    public final boolean setUnstableIfMergeFails;
 
     @DataBoundConstructor
-    public RebaseBuilder(String permalink, boolean stopBuildIfMergeFails) {
+    public RebaseBuilder(String permalink, boolean stopBuildIfMergeFails, boolean setUnstableIfMergeFails) {
         this.permalink = permalink;
         this.stopBuildIfMergeFails = stopBuildIfMergeFails;
+        this.setUnstableIfMergeFails = setUnstableIfMergeFails;
     }
 
     @Override
@@ -48,6 +51,9 @@ public class RebaseBuilder extends Builder {
 
     	RebaseAction rebaseAction = new  RebaseAction(project);
     	long result = rebaseAction.perform(listener,new RebaseSetting(permalink));
+        if(result<0){
+            build.setResult(Result.UNSTABLE);
+        }
         return !stopBuildIfMergeFails || result >= 0;
     }
 

--- a/src/main/java/jenkins/plugins/svnmerge/Utility.java
+++ b/src/main/java/jenkins/plugins/svnmerge/Utility.java
@@ -1,6 +1,6 @@
 package jenkins.plugins.svnmerge;
 
-import hudson.EnvVars; 
+import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.Computer;
 import hudson.model.Job;
@@ -19,10 +19,16 @@ class Utility {
     /**
      * Get either the provided build of the root build of the provided
      * build if it is a promotion one.
+     * also use the root build of a matrix build
      */
     static AbstractBuild<?,?> rootBuildOf(AbstractBuild build) {
         if (Jenkins.getInstance().getPlugin("promoted-builds") != null) {
             if (build instanceof hudson.plugins.promoted_builds.Promotion) {
+                return build.getRootBuild();
+            }
+        }
+        if (Jenkins.getInstance().getPlugin("matrix-project") != null) {
+            if (build instanceof hudson.matrix.MatrixBuild) {
                 return build.getRootBuild();
             }
         }

--- a/src/main/resources/jenkins/plugins/svnmerge/RebaseBuilder/config.groovy
+++ b/src/main/resources/jenkins/plugins/svnmerge/RebaseBuilder/config.groovy
@@ -8,3 +8,6 @@ f.entry(title:_("Build to rebase to"), field:"permalink") {
 f.entry(title:_("Stop the build if the merge fails"), field:"stopBuildIfMergeFails") {
 	f.checkbox()
 }
+f.entry(title:_("Make the build UNSTABLE if the merge fails"), field:"setUnstableIfMergeFails") {
+	f.checkbox()
+}


### PR DESCRIPTION
Currently the merge plugin only allows builds to either continue or halt when a merge fails.
For our purposes it was useful to continue the build, but highlight the failure by marking the build as unstable. These changes allow this behaviour.

In addition the GetRootProject function was also extended to support matrix style builds