### PR TITLE
[JENKINS-30769] Rebase commit prefix

### DIFF
--- a/src/main/java/jenkins/plugins/svnmerge/FeatureBranchProperty.java
+++ b/src/main/java/jenkins/plugins/svnmerge/FeatureBranchProperty.java
@@ -76,7 +76,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
     private String upstream;
     private transient RebaseAction rebaseAction;
     
-    private final String commitPrefix;
+    private final String rebaseCommitPrefix;
 
     @DataBoundConstructor
     public FeatureBranchProperty(String upstream, String rebaseCommitPrefix) {
@@ -84,8 +84,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
             throw new NullPointerException("upstream");
         }
         this.upstream = upstream;
-        this.commitPrefix = (rebaseCommitPrefix == null || "".equals(rebaseCommitPrefix)) ? 
-				RebaseAction.COMMIT_MESSAGE_PREFIX : rebaseCommitPrefix;;
+        this.rebaseCommitPrefix = rebaseCommitPrefix;
     }
 
     public String getUpstream() {
@@ -93,7 +92,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
     }
     
     public String getRebaseCommitPrefix() {
-		return commitPrefix;
+		return rebaseCommitPrefix;
 	}
     
 
@@ -222,7 +221,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
 							
 							SVNCommitClient cc = cm.getCommitClient();
 							SVNCommitInfo ci = cc.doCommit(new File[] { mr },
-									false, commitPrefix	+ "Rebasing from " + up + "@"
+									false, getCommitPrefix() + " Rebasing from " + up + "@"
 											+ mergeRev, null, null, false,
 									false, INFINITY);
 							if (ci.getNewRevision() < 0) {
@@ -332,7 +331,8 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
                                 if (!changesFound.booleanValue()) {
                                 	String message = e.getMessage();
                                 	
-                                    if (!message.startsWith(commitPrefix)
+                                    String commitPrefix = getCommitPrefix();
+									if (!message.startsWith(commitPrefix)
                                     		&& !message.startsWith(commitPrefix)) {
                                     	changesFound.setValue(true);
                                     }
@@ -480,5 +480,11 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
         }
     }
 
+    private String getCommitPrefix(){
+    	return (rebaseCommitPrefix == null || "".equals(rebaseCommitPrefix)) ? 
+    			RebaseAction.COMMIT_MESSAGE_PREFIX : rebaseCommitPrefix;
+    }
+    
     private static final Logger LOGGER = Logger.getLogger(FeatureBranchProperty.class.getName());
+    
 }

--- a/src/main/java/jenkins/plugins/svnmerge/FeatureBranchProperty.java
+++ b/src/main/java/jenkins/plugins/svnmerge/FeatureBranchProperty.java
@@ -221,7 +221,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
 							
 							SVNCommitClient cc = cm.getCommitClient();
 							SVNCommitInfo ci = cc.doCommit(new File[] { mr },
-									false, getCommitPrefix() + " Rebasing from " + up + "@"
+									false, getFinalRebaseCommitPrefix() + " Rebasing from " + up + "@"
 											+ mergeRev, null, null, false,
 									false, INFINITY);
 							if (ci.getNewRevision() < 0) {
@@ -331,7 +331,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
                                 if (!changesFound.booleanValue()) {
                                 	String message = e.getMessage();
                                 	
-                                    String commitPrefix = getCommitPrefix();
+                                    String commitPrefix = getFinalRebaseCommitPrefix();
 									if (!message.startsWith(commitPrefix)
                                     		&& !message.startsWith(commitPrefix)) {
                                     	changesFound.setValue(true);
@@ -362,7 +362,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
                     } else {
                         logger.println("Committing changes to the upstream");
                         SVNCommitClient cc = cm.getCommitClient();
-                        ci = cc.doCommit(new File[]{mr}, false, commitMessage+"\n"+mergeUrl+"@"+mergeRev, null, null, false, false, INFINITY);
+                        ci = cc.doCommit(new File[]{mr}, false, getCommitPrefix() + commitMessage+"\n"+mergeUrl+"@"+mergeRev, null, null, false, false, INFINITY);
                         if(ci.getNewRevision()<0)
                             logger.println("  No changes since the last integration");
                         else
@@ -410,7 +410,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
                             return new IntegrationResult(-1,mergeRev);
                         }
 
-                        String msg = RebaseAction.COMMIT_MESSAGE_PREFIX+"Rebasing with the integration commit that was just made in rev."+trunkCommit;
+                        String msg = getCommitPrefix() + RebaseAction.COMMIT_MESSAGE_PREFIX+"Rebasing with the integration commit that was just made in rev."+trunkCommit;
                         SVNCommitInfo bci = cc.doCommit(new File[]{mr}, false, msg, null, null, false, false, INFINITY);
                         logger.println("  committed revision "+bci.getNewRevision());
                     }
@@ -480,9 +480,13 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
         }
     }
 
-    private String getCommitPrefix(){
+    private String getFinalRebaseCommitPrefix(){
     	return (rebaseCommitPrefix == null || "".equals(rebaseCommitPrefix)) ? 
     			RebaseAction.COMMIT_MESSAGE_PREFIX : rebaseCommitPrefix;
+    }
+    
+    private String getCommitPrefix(){
+    	return rebaseCommitPrefix == null ? "": rebaseCommitPrefix;
     }
     
     private static final Logger LOGGER = Logger.getLogger(FeatureBranchProperty.class.getName());

--- a/src/main/java/jenkins/plugins/svnmerge/FeatureBranchProperty.java
+++ b/src/main/java/jenkins/plugins/svnmerge/FeatureBranchProperty.java
@@ -57,8 +57,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.Nullable;
-
 import static org.tmatesoft.svn.core.SVNDepth.*;
 import static org.tmatesoft.svn.core.wc.SVNRevision.*;
 

--- a/src/main/java/jenkins/plugins/svnmerge/IntegratableProjectAction.java
+++ b/src/main/java/jenkins/plugins/svnmerge/IntegratableProjectAction.java
@@ -108,7 +108,9 @@ public class IntegratableProjectAction extends AbstractModelObject implements Ac
     						@QueryParameter String commitMessage, 
     						@QueryParameter String branchLocation,
     						@QueryParameter boolean createTag,
-    						@QueryParameter String tagLocation) throws ServletException, IOException {
+    						@QueryParameter String tagLocation,
+    						@QueryParameter boolean useCustomMergeCommitPrefix,
+    						@QueryParameter String rebaseCommitPrefix) throws ServletException, IOException {
         
         name = Util.fixEmptyAndTrim(name);
         
@@ -216,7 +218,8 @@ public class IntegratableProjectAction extends AbstractModelObject implements Ac
     	BulkChange bc = new BulkChange(copy);
     	try {
     		copy.removeProperty(IntegratableProject.class);
-    		((AbstractProject)copy).addProperty(new FeatureBranchProperty(project.getName())); // pointless cast for working around javac bug as of JDK1.6.0_02
+    		((AbstractProject)copy).addProperty(new FeatureBranchProperty(project.getName(), 
+    				rebaseCommitPrefix)); // pointless cast for working around javac bug as of JDK1.6.0_02
     		// update the SCM config to point to the branch
     		SubversionSCM svnScm = (SubversionSCM)copy.getScm();
     		copy.setScm(

--- a/src/main/resources/jenkins/plugins/svnmerge/FeatureBranchProperty/config.groovy
+++ b/src/main/resources/jenkins/plugins/svnmerge/FeatureBranchProperty/config.groovy
@@ -13,6 +13,13 @@ f.optionalBlock(name:"svnmerge", title:_("This project builds a Subversion featu
                     }
                 }
             }
+            f.entry(title:_("Rebase commit prefix")){
+            	f.textbox(id:h.generateId(), field:"rebaseCommitPrefix", clazz:"setting-input"){
+            		descriptor.listIntegratableProjects().each { u ->
+                        f.textbox(value:u.name)
+                    }
+            	}
+            }
         }
     }
 }

--- a/src/main/resources/jenkins/plugins/svnmerge/IntegratableProjectAction/index.groovy
+++ b/src/main/resources/jenkins/plugins/svnmerge/IntegratableProjectAction/index.groovy
@@ -117,6 +117,16 @@ l.layout(norefresh:"true",title:_("title",my.project.displayName)) {
                         }
                     
                     }
+
+                    tr {
+                        td (class: "setting-leftspace")
+                        td (class: "setting-name") {
+                            text(_("Rebase commit prefix")+":")
+                        }
+                        td (class: "setting-main") {
+                            input (type:"text", name:"rebaseCommitPrefix", class:"setting-input")
+                        }
+                    }
                 
                 }
 				

--- a/src/main/webapp/help/upstream.html
+++ b/src/main/webapp/help/upstream.html
@@ -27,6 +27,10 @@
     Merge can be done repeatedly and bidirectionally
     (that is, you can merge between the trunk and the branch back and forth
     as many times as you need, so that the branch can follow the trunk closely)
+    
+    <p>
+    Leave the "Rebase commit prefix" blank to use the default value "[REBASE]", otherwise 
+    the prefix entered will be used in all the rebase commits 
 
     <p>
     This feature requires Subversion 1.5 on the server.

--- a/src/test/java/jenkins/plugins/svnmerge/FeatureBranchPropertyTest.java
+++ b/src/test/java/jenkins/plugins/svnmerge/FeatureBranchPropertyTest.java
@@ -37,7 +37,7 @@ public class FeatureBranchPropertyTest extends HudsonTestCase {
 
     public void testConfigRoundtrip2() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
-        p.addProperty(new FeatureBranchProperty("xyz"));
+        p.addProperty(new FeatureBranchProperty("xyz","zyx"));
         HtmlPage page = new WebClient().getPage(p, "configure");
         submit(page.getFormByName("config"));
         FeatureBranchProperty ujp = p.getProperty(FeatureBranchProperty.class);
@@ -56,7 +56,7 @@ public class FeatureBranchPropertyTest extends HudsonTestCase {
 		ParameterDefinition def1 = new StringParameterDefinition("REPO", "a");
 		ParameterDefinition def2 = new StringParameterDefinition("PROJECT", "b");
 		p.addProperty(new ParametersDefinitionProperty(def1,def2));
-		FeatureBranchProperty jobProp = new FeatureBranchProperty(p.getName());
+		FeatureBranchProperty jobProp = new FeatureBranchProperty(p.getName(),null);
 		FreeStyleProject p2 = createFreeStyleProject();
 		p2.addProperty(jobProp);
 		assertEquals( "https://root/a/b/trunk",jobProp.getUpstreamURL().toDecodedString());

--- a/src/test/java/jenkins/plugins/svnmerge/MergeTest.java
+++ b/src/test/java/jenkins/plugins/svnmerge/MergeTest.java
@@ -60,7 +60,7 @@ public class MergeTest extends HudsonTestCase {
         // create a project
         p = createFreeStyleProject("b1");
         p.setScm(new SubversionSCM("file://"+new URL(repo,"branches/b1").getPath(),"b1"));
-        upp = new FeatureBranchProperty(trunk.getName());
+        upp = new FeatureBranchProperty(trunk.getName(),null);
         p.addProperty(upp);
 
         // check out workspace so that we can simulate commits outside Jenkins


### PR DESCRIPTION
With this change it's possible to specify a prefix message that will be applied to the rebase commit message. If blank, the default will be used.
