### PR TITLE
Added support for multiple SVN Modules.

### DIFF
--- a/src/main/java/jenkins/plugins/svnmerge/AbstractSvnmergeTaskAction.java
+++ b/src/main/java/jenkins/plugins/svnmerge/AbstractSvnmergeTaskAction.java
@@ -27,6 +27,7 @@ import javax.servlet.ServletException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -90,7 +91,7 @@ public abstract class AbstractSvnmergeTaskAction<P> extends TaskAction {
      * <p>
      * This requires that the calling thread owns the workspace.
      */
-    /*package*/ abstract long perform(TaskListener listener, P param) throws IOException, InterruptedException;
+    /*package*/ abstract List<Long> perform(TaskListener listener, P param) throws IOException, InterruptedException;
 
     /**
      * Which page to render in the top page?

--- a/src/main/java/jenkins/plugins/svnmerge/IntegrationPublisher.java
+++ b/src/main/java/jenkins/plugins/svnmerge/IntegrationPublisher.java
@@ -16,6 +16,7 @@ import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * {@link Publisher} that integrates the current workspace to the upstream. 
@@ -48,8 +49,17 @@ public class IntegrationPublisher extends Publisher {
             return false;
         }
 
-        if(ia.perform(listener,new IntegrateSetting())<0)
+        List<Long> integrationResults = ia.perform(listener,new IntegrateSetting());
+
+        if(integrationResults != null && integrationResults.size() > 0){
+            for(Long result : integrationResults){
+                if(result<0)
+                    build.setResult(Result.FAILURE);
+            }
+        } else {
             build.setResult(Result.FAILURE);
+        }
+
         return true;
     }
 

--- a/src/main/java/jenkins/plugins/svnmerge/RebaseBuilder.java
+++ b/src/main/java/jenkins/plugins/svnmerge/RebaseBuilder.java
@@ -16,6 +16,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -50,11 +51,21 @@ public class RebaseBuilder extends Builder {
         }
 
     	RebaseAction rebaseAction = new  RebaseAction(project);
-    	long result = rebaseAction.perform(listener,new RebaseSetting(permalink));
-        if(result<0){
-            build.setResult(Result.UNSTABLE);
+    	List<Long> results = rebaseAction.perform(listener,new RebaseSetting(permalink));
+        boolean buildStable = true;
+
+        if(results != null && results.size() > 0){
+            for(Long result : results){
+                if(result<0){
+                    build.setResult(Result.UNSTABLE);
+                    buildStable = false;
+                }
+            }
+        } else {
+            buildStable = false;
         }
-        return !stopBuildIfMergeFails || result >= 0;
+
+        return !stopBuildIfMergeFails || buildStable;
     }
 
     @Extension

--- a/src/main/resources/jenkins/plugins/svnmerge/IntegratableProjectAction/index.groovy
+++ b/src/main/resources/jenkins/plugins/svnmerge/IntegratableProjectAction/index.groovy
@@ -24,7 +24,7 @@ l.layout(norefresh:"true",title:_("title",my.project.displayName)) {
 		def repoLayout = my.repositoryLayout
 		p(_("Repository URL: "+repoLayout.scmModuleLocation))
 		p(_("Detected repository layout: "+repoLayout.layout))
-		if (StringUtils.isNotEmpty(repoLayout.subProjectName)) {
+		if (repoLayout.subProjectName != null) {
 			p(_("Detected subproject name: "+repoLayout.subProjectName))
 		}
 

--- a/src/test/java/jenkins/plugins/svnmerge/FeatureBranchPropertyTest.java
+++ b/src/test/java/jenkins/plugins/svnmerge/FeatureBranchPropertyTest.java
@@ -23,6 +23,8 @@ import hudson.slaves.NodeProperty;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.tmatesoft.svn.core.SVNURL;
+import org.tmatesoft.svn.core.wc.SVNInfo;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -48,7 +50,7 @@ public class FeatureBranchPropertyTest extends HudsonTestCase {
 	@Bug(24735)
 	public void testUpStreamURLwithParams()
 			throws Exception {
-		EnvironmentVariablesNodeProperty envNodeProp = new EnvironmentVariablesNodeProperty(new hudson.slaves.EnvironmentVariablesNodeProperty.Entry("ROOT_SVN_URL", "root/"));	
+		EnvironmentVariablesNodeProperty envNodeProp = new EnvironmentVariablesNodeProperty(new hudson.slaves.EnvironmentVariablesNodeProperty.Entry("ROOT_SVN_URL", "root/"));
 		Computer.currentComputer().getNode().getNodeProperties().add(envNodeProp);
 		Jenkins.getInstance().getDescriptorList(JobProperty.class).add(new FeatureBranchProperty.DescriptorImpl());
 		FreeStyleProject p = createFreeStyleProject();
@@ -59,7 +61,9 @@ public class FeatureBranchPropertyTest extends HudsonTestCase {
 		FeatureBranchProperty jobProp = new FeatureBranchProperty(p.getName());
 		FreeStyleProject p2 = createFreeStyleProject();
 		p2.addProperty(jobProp);
-		assertEquals( "https://root/a/b/trunk",jobProp.getUpstreamURL().toDecodedString());
+		for(SVNURL svnURL : jobProp.getUpstreamURL()){
+			assertEquals( "https://root/a/b/trunk",svnURL.toDecodedString());
+		}
 	}
     
     

--- a/src/test/java/jenkins/plugins/svnmerge/MergeTest.java
+++ b/src/test/java/jenkins/plugins/svnmerge/MergeTest.java
@@ -122,13 +122,17 @@ public class MergeTest extends HudsonTestCase {
      */
     private boolean trunkHasE() throws SVNException {
         // make sure the merge went in by checking if /trunk/e exists.
-        SVNRepository rep = SVNRepositoryFactory.create(upp.getUpstreamURL());
-        long latest = rep.getLatestRevision();
-        try {
-            return latest==rep.getFile("/trunk/e", latest,new SVNProperties(), null);
-        } catch (SVNException e) {
-            return false;
+        boolean toReturn = false;
+        for(SVNURL url : upp.getUpstreamURL()){
+            SVNRepository rep = SVNRepositoryFactory.create(url);
+            long latest = rep.getLatestRevision();
+            try {
+                toReturn = latest==rep.getFile("/trunk/e", latest,new SVNProperties(), null);
+            } catch (SVNException e) {
+                return false;
+            }
         }
+        return toReturn;
     }
 
     /**


### PR DESCRIPTION
Added multiple **_SVN Modules_** support for **_Feature Branch_**, **_Rebase_** and
**_Integrate_** actions. 

Also, for **_Feature Branch_**, all **_SVN Modules_** will be copied to child-job.

In **_FeatureBranchProperty_**, inside method **_integrate_**, I've found no way to get for a **_ModuleLocation_** corresponding Job checkout folder. So if you look at line **_334_**, I am iterating through **_svnModules_** and with current index, I get corresponding svn checkout folder from  **_upstreamLocations_**. With other words I hope that indexes will match. I didn't research much about this, so if there is another prettier solution, please let me know. 