### PR TITLE
Remove usage of deprecated IOException2

### DIFF
--- a/src/main/java/jenkins/plugins/svnmerge/FeatureBranchProperty.java
+++ b/src/main/java/jenkins/plugins/svnmerge/FeatureBranchProperty.java
@@ -21,7 +21,6 @@ import hudson.scm.SvnClientManager;
 import hudson.scm.SubversionSCM.ModuleLocation;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
-import hudson.util.IOException2;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
@@ -68,8 +67,8 @@ import static org.tmatesoft.svn.core.wc.SVNRevision.*;
  * @author Kohsuke Kawaguchi
  */
 public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> implements Serializable {
-    private static final long serialVersionUID = -1L; 
-    
+    private static final long serialVersionUID = -1L;
+
     /**
      * Upstream job name.
      */
@@ -117,7 +116,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
         if(location==null)  return null;
         return location.getSVNURL();
     }
-    
+
     public AbstractProject<?,?> getOwner() {
         return owner;
     }
@@ -162,7 +161,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
         final ISVNAuthenticationProvider provider = svn.createAuthenticationProvider(getOwner(), svn.getLocations()[0]);
 
         final ModuleLocation upstreamLocation = getUpstreamSubversionLocation();
-        
+
         AbstractBuild build = owner.getSomeBuildWithWorkspace();
         if (build == null) {
             final PrintStream logger = listener.getLogger();
@@ -233,7 +232,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
 						}
                     }
                 } catch (SVNException e) {
-                    throw new IOException2("Failed to merge", e);
+                    throw new IOException("Failed to merge", e);
                 }
             }
         });
@@ -243,7 +242,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
      * Represents the result of integration.
      */
     public static class IntegrationResult implements Serializable {
-        private static final long serialVersionUID = -1L; 
+        private static final long serialVersionUID = -1L;
 
         /**
          * The merge commit in the upstream where the integration is made visible to the upstream.
@@ -288,7 +287,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
         final ISVNAuthenticationProvider provider = svn.createAuthenticationProvider(getUpstreamProject(), svn.getLocations()[0]);
 
         final ModuleLocation upstreamLocation = getUpstreamSubversionLocation();
-        
+
         return owner.getModuleRoot().act(new FileCallable<IntegrationResult>() {
             public IntegrationResult invoke(File mr, VirtualChannel virtualChannel) throws IOException {
                 try {
@@ -322,7 +321,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
                             public void handleLogEntry(SVNLogEntry e) throws SVNException {
                                 if (!changesFound.booleanValue()) {
                                 	String message = e.getMessage();
-                                	
+
                                     if (!message.startsWith(RebaseAction.COMMIT_MESSAGE_PREFIX)
                                     		&& !message.startsWith(IntegrateAction.COMMIT_MESSAGE_PREFIX)) {
                                     	changesFound.setValue(true);
@@ -336,7 +335,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
 	                        return new IntegrationResult(0,mergeRev);
                         }
                     }
-                    
+
                     logger.println("Switching to the upstream (" + up+")");
                     SVNUpdateClient uc = cm.getUpdateClient();
                     uc.doSwitch(mr, up, HEAD, HEAD, INFINITY, false, false);
@@ -409,7 +408,7 @@ public class FeatureBranchProperty extends JobProperty<AbstractProject<?,?>> imp
                     // -1 is returned if there was no commit, so normalize that to 0
                     return new IntegrationResult(Math.max(0,trunkCommit),mergeRev);
                 } catch (SVNException e) {
-                    throw new IOException2("Failed to merge", e);
+                    throw new IOException("Failed to merge", e);
                 }
             }
         });

--- a/src/test/java/jenkins/plugins/svnmerge/MergeTest.java
+++ b/src/test/java/jenkins/plugins/svnmerge/MergeTest.java
@@ -8,7 +8,6 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.scm.SubversionSCM;
-import hudson.util.IOException2;
 import org.apache.commons.io.FileUtils;
 import org.jvnet.hudson.test.HudsonHomeLoader.CopyExisting;
 import org.jvnet.hudson.test.HudsonTestCase;
@@ -223,7 +222,7 @@ public class MergeTest extends HudsonTestCase {
     /**
      * Add a file and then commit the directory.
      */
-    private void commitAndUpdate(BuildListener listener, FilePath dir, FilePath newFile) throws IOException2 {
+    private void commitAndUpdate(BuildListener listener, FilePath dir, FilePath newFile) throws IOException {
         try {
             SVNClientManager cm = SubversionSCM.createSvnClientManager(p);
 
@@ -233,7 +232,7 @@ public class MergeTest extends HudsonTestCase {
 
             cm.getUpdateClient().doUpdate(new File(dir.getRemote()), HEAD, INFINITY, false, true);
         } catch (SVNException x) {
-            throw new IOException2("failed to commit",x);
+            throw new IOException("failed to commit",x);
         }
     }
 


### PR DESCRIPTION
## Remove usage of deprecated IOException2

Removes usage of deprecated `hudson.util.IOException2` by replacing it with `java.io.IOException`

### Testing done

None, rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
